### PR TITLE
Update Dockerfile to use goa-build image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 ### Multi-stage build
-FROM golang:1.8.3-alpine3.6 as build
-
-RUN apk --no-cache add git curl openssh
-
-RUN go get -u -v github.com/goadesign/goa/... && \
-    go get -u -v gopkg.in/mgo.v2 && \
-    go get -u -v golang.org/x/crypto/bcrypt && \
-    go get -u -v github.com/JormungandrK/microservice-security/... && \
-    go get -u -v github.com/JormungandrK/microservice-tools
+FROM jormungandrk/goa-build as build
 
 COPY . /go/src/github.com/JormungandrK/user-microservice
 RUN go install github.com/JormungandrK/user-microservice


### PR DESCRIPTION
Don't merge until we have access to the jormungandrk organization on DockerHub, because we won't be able to pull the image.